### PR TITLE
change delay in bt_send.c to 40ms

### DIFF
--- a/adruino/bt_send.c
+++ b/adruino/bt_send.c
@@ -64,7 +64,7 @@ void loop() {
     while (central.connected()) {
       digitalWrite(ledPin, HIGH);   
       updateValue();
-      delay(100);
+      delay(40); // 40ms => 25 readings/sec => voting can have a odd number to break the tie
     }
 
     // when the central disconnects, print it out:


### PR DESCRIPTION
change delay in bt_send.c to 40ms. The receiver gets 25 readings per second from the sender. In that case, the voting in the receiver end can have 25 readings in the buffer to break the tie.